### PR TITLE
Feat: use store if available

### DIFF
--- a/btp-plugin.js
+++ b/btp-plugin.js
@@ -376,6 +376,7 @@ class AbstractBtpPlugin extends EventEmitter {
         JSON.stringify(transfer))
     }
 
+    console.log('INCOMING FULFILL')
     this._safeEmit('incoming_fulfill', transfer, fulfillment, ilp)
 
     await this._call(transfer.from, {
@@ -398,6 +399,7 @@ class AbstractBtpPlugin extends EventEmitter {
     const { ilp } = protocolDataToIlpAndCustom(data)
     const transfer = this._getOutgoingTransferById(transferId)
 
+    console.log('OUTGOING FULFILL')
     this._safeEmit('outgoing_fulfill', transfer, data.fulfillment, ilp)
 
     this._outgoingTransfers.delete(transferId)

--- a/btp-plugin.js
+++ b/btp-plugin.js
@@ -2,7 +2,7 @@
 
 const crypto = require('crypto')
 const debug = require('debug')('ilp-plugin-mini-accounts:btp-plugin')
-const EventEmitter = require('events').EventEmitter
+const EventEmitter = require('eventemitter2')
 const BtpPacket = require('btp-packet')
 const IlpPacket = require('ilp-packet')
 const base64url = require('base64url')

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const WebSocket = require('ws')
 const assert = require('assert')
 const debug = require('debug')('ilp-plugin-mini-accounts')
 const AbstractBtpPlugin = require('./btp-plugin')
+const StoreWrapper = require('./store-wrapper')
 const base64url = require('base64url')
 
 function tokenToAccount (token) {
@@ -30,7 +31,7 @@ class Plugin extends AbstractBtpPlugin {
 
     this._log = opts._log || console
     this._wss = null
-    this._balances = new Map()
+    this._balances = new StoreWrapper(opts._store)
     this._connections = new Map()
 
     this.on('outgoing_fulfill', this._handleOutgoingFulfill.bind(this))
@@ -102,11 +103,14 @@ class Plugin extends AbstractBtpPlugin {
           }
           debug(`account ${account}: processing btp packet ${JSON.stringify(btpPacket)}`)
           try {
+            let operation = Promise.resolve()
             if (btpPacket.type === BtpPacket.TYPE_PREPARE) {
-              this._handleIncomingBtpPrepare(account, btpPacket)
+              operation = this._handleIncomingBtpPrepare(account, btpPacket)
             }
             debug('packet is authorized, forwarding to host')
-            this._handleIncomingBtpPacket(this._prefix + account, btpPacket)
+            operation.then(() => {
+              this._handleIncomingBtpPacket(this._prefix + account, btpPacket)
+            })
           } catch (err) {
             debug('btp packet not accepted', err)
             const errorResponse = BtpPacket.serializeError({
@@ -137,14 +141,15 @@ class Plugin extends AbstractBtpPlugin {
     return !!this._wss
   }
 
-  _handleIncomingBtpPrepare (account, btpPacket) {
+  async _handleIncomingBtpPrepare (account, btpPacket) {
     const prepare = btpPacket.data
     if (prepare.protocolData.length < 1 || prepare.protocolData[0].protocolName !== 'ilp') {
       throw new Error('ILP packet is required')
     }
     // const ilp = IlpPacket.deserializeIlpPayment(prepare.protocolData[0].data)
 
-    const currentBalance = this._balances.get(account) || new BigNumber(0)
+    await this._balances.load(account)
+    const currentBalance = new BigNumber(this._balances.get(account) || 0)
 
     const newBalance = currentBalance.sub(prepare.amount)
 
@@ -152,27 +157,31 @@ class Plugin extends AbstractBtpPlugin {
       throw new Error('Insufficient funds, have: ' + currentBalance + ' need: ' + prepare.amount)
     }
 
-    this._balances.set(account, newBalance)
+    this._balances.set(account, newBalance.toString())
 
     debug(`account ${account} debited ${prepare.amount} units, new balance ${newBalance}`)
   }
 
-  _handleOutgoingFulfill (transfer) {
+  async _handleOutgoingFulfill (transfer) {
     const account = ilpAddressToAccount(this._prefix, transfer.to)
-    const currentBalance = this._balances.get(account) || new BigNumber(0)
+    await this._balances.load(account)
+
+    const currentBalance = new BigNumber(this._balances.get(account) || 0)
     const newBalance = currentBalance.add(transfer.amount)
 
-    this._balances.set(account, newBalance)
+    this._balances.set(account, newBalance.toString())
 
     debug(`account ${account} credited ${transfer.amount} units, new balance ${newBalance}`)
   }
 
-  _handleIncomingReject (transfer) {
+  async _handleIncomingReject (transfer) {
     const account = ilpAddressToAccount(this._prefix, transfer.from)
-    const currentBalance = this._balances.get(account) || new BigNumber(0)
+    await this._balances.load(account)
+
+    const currentBalance = new BigNumber(this._balances.get(account) || 0)
     const newBalance = currentBalance.add(transfer.amount)
 
-    this._balances.set(account, newBalance)
+    this._balances.set(account, newBalance.toString())
 
     debug(`account ${account} credited ${transfer.amount} units, new balance ${newBalance}`)
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "base64url": "^2.0.0",
     "btp-packet": "^1.0.0",
     "debug": "^3.1.0",
+    "eventemitter2": "^4.1.2",
     "ilp-plugin-payment-channel-framework": "^1.0.1",
     "int64": "0.0.5",
     "uuid": "^3.1.0",

--- a/store-wrapper.js
+++ b/store-wrapper.js
@@ -1,0 +1,25 @@
+class StoreWrapper {
+  constructor (store) {
+    this._store = store
+    this._cache = new Map()
+    this._write = Promise.resolve()
+  }
+
+  async load (key) {
+    if (!this._store) return
+    this._cache.set(key, await this._store.get(key))
+  }
+
+  get (key) {
+    return this._cache.get(key)
+  }
+
+  set (key, value) {
+    this._cache.set(key, value)
+    this._write = this._write.then(() => {
+      return this._store.put(key, value)
+    })
+  }
+}
+
+module.exports = StoreWrapper

--- a/store-wrapper.js
+++ b/store-wrapper.js
@@ -7,6 +7,7 @@ class StoreWrapper {
 
   async load (key) {
     if (!this._store) return
+    if (this._cache.get(key)) return
     this._cache.set(key, await this._store.get(key))
   }
 
@@ -14,11 +15,13 @@ class StoreWrapper {
     return this._cache.get(key)
   }
 
-  set (key, value) {
+  set (key, value, persist) {
     this._cache.set(key, value)
-    this._write = this._write.then(() => {
-      return this._store.put(key, value)
-    })
+    if (persist) {
+      this._write = this._write.then(() => {
+        return this._store.put(key, value)
+      })
+    }
   }
 }
 


### PR DESCRIPTION
Adds persistence by accepting `opts.store`. The store is wrapped in a `StoreWrapper`, which holds onto the store and keeps a cache. Before accessing any field, the `load` operation is done, which loads the field into the cache. This guarantees that any other changes will be applied to the cache synchronously. Writes are done via a promise chain to ensure proper ordering.