### PR TITLE
fix: ilp packet in fulfillCondition must be buffer

### DIFF
--- a/btp-plugin.js
+++ b/btp-plugin.js
@@ -365,7 +365,11 @@ class AbstractBtpPlugin extends EventEmitter {
 
   async fulfillCondition (transferId, fulfillment, ilp) {
     const protocolData = ilp
-      ? [{ protocolName: 'ilp', contentType: BtpPacket.MIME_APPLICATION_OCTET_STREAM, data: ilp }]
+      ? [{
+        protocolName: 'ilp',
+        contentType: BtpPacket.MIME_APPLICATION_OCTET_STREAM,
+        data: Buffer.from(ilp, 'base64')
+      }]
       : []
     const requestId = await _requestId()
 

--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ class Plugin extends AbstractBtpPlugin {
 
       result.catch(err => {
         const errorInfo = (typeof err === 'object' && err.stack) ? err.stack : String(err)
-        debug('unable to send btp message to client: ' + errorInfo)
+        debug('unable to send btp message to client: ' + errorInfo, 'btp packet:', JSON.stringify(btpPacket))
       })
     })
 


### PR DESCRIPTION
the btp-packet module expects a buffer, not a base64-encoded string