### PR TITLE
Feat: derive multi-plugin from mini-accounts

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,17 +20,11 @@ class Plugin extends AbstractBtpPlugin {
     const defaultPort =  opts.port || 3000
     this._wsOpts = opts.wsOpts || { port: defaultPort }
     this._currencyScale = opts.currencyScale || 9
-    this._modeInfiniteBalances = !!opts.debugInfiniteBalances
     this._debugHostIldcpInfo = opts.debugHostIldcpInfo
 
     this._log = opts._log || console
     this._wss = null
-    this._balances = new Map()
     this._connections = new Map()
-
-    if (this._modeInfiniteBalances) {
-      this._log.warn('(!!!) granting all users infinite balances')
-    }
   }
 
   ilpAddressToAccount (ilpAddress) {

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ class Plugin extends AbstractBtpPlugin {
     this._wsOpts = opts.wsOpts || { port: defaultPort }
     this._currencyScale = opts.currencyScale || 9
     this._modeInfiniteBalances = !!opts.debugInfiniteBalances
+    this._debugHostIldcpInfo = opts.debugHostIldcpInfo
 
     this._log = opts._log || console
     this._wss = null
@@ -43,7 +44,7 @@ class Plugin extends AbstractBtpPlugin {
   async connect () {
     if (this._wss) return
 
-    this._hostIldcpInfo = await ILDCP.fetch(this._dataHandler.bind(this))
+    this._hostIldcpInfo = this._debugHostIldcpInfo || await ILDCP.fetch(this._dataHandler.bind(this))
     this._prefix = this._hostIldcpInfo.clientAddress + '.'
 
     debug('listening on port ' + this._wsOpts.port)

--- a/index.js
+++ b/index.js
@@ -149,12 +149,14 @@ class Plugin extends AbstractBtpPlugin {
     const parsedPacket = IlpPacket.deserializeIlpPacket(buffer)
 
     let destination
+    let isPrepare = false
     switch (parsedPacket.type) {
       case IlpPacket.Type.TYPE_ILP_PAYMENT:
       case IlpPacket.Type.TYPE_ILP_FORWARDED_PAYMENT:
         destination = parsedPacket.data.account
         break
       case IlpPacket.Type.TYPE_ILP_PREPARE:
+        isPrepare = true
         destination = parsedPacket.data.destination
         if (this._sendPrepare) {
           this._sendPrepare(destination, parsedPacket)
@@ -190,7 +192,7 @@ class Plugin extends AbstractBtpPlugin {
     const ilpResponse = response.protocolData
       .filter(p => p.protocolName === 'ilp')[0]
 
-    if (this._handlePrepareResponse) {
+    if (isPrepare && this._handlePrepareResponse) {
       this._handlePrepareResponse(destination,
         IlpPacket.deserializeIlpPacket(ilpResponse.data),
         parsedPacket)
@@ -225,7 +227,7 @@ class Plugin extends AbstractBtpPlugin {
     }
 
     if (this._handleCustomData) {
-      debug('passing non-ilp data to custom handler')
+      debug('passing non-ILDCP data to custom handler')
       return this._handleCustomData(from, btpPacket)
     }
 

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ class Plugin extends AbstractBtpPlugin {
 
     debug('listening on port ' + this._wsOpts.port)
     const wss = this._wss = new WebSocket.Server(this._wsOpts)
-    wss.on('connection', (wsIncoming) => {
+    wss.on('connection', (wsIncoming, req) => {
       debug('got connection')
       let token
       let account
@@ -78,14 +78,16 @@ class Plugin extends AbstractBtpPlugin {
           assert(token, 'auth_token subprotocol is required')
 
           if (this._connect) {
-            await this._connect(this._prefix + account, authPacket)
+            await this._connect(this._prefix + account, authPacket, {
+              ws: wsIncoming,
+              req
+            })
           }
 
           wsIncoming.send(BtpPacket.serializeResponse(authPacket.requestId, []))
         } catch (err) {
           if (authPacket) {
             debug('not accepted error during auth. error=', err)
-            debug(typeof err)
             const errorResponse = BtpPacket.serializeError({
               code: 'F00',
               name: 'NotAcceptedError',

--- a/package-lock.json
+++ b/package-lock.json
@@ -912,14 +912,22 @@
       }
     },
     "ilp-plugin-btp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ilp-plugin-btp/-/ilp-plugin-btp-1.0.1.tgz",
-      "integrity": "sha512-hLw5gEmDkHl+Uw0k88NT3Wg0AQTNKAQMr79v03iQtzTyYYGcRWarngqJ8vTKdwKvCf1u9ZPEwaaHL5VzUEEdzA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ilp-plugin-btp/-/ilp-plugin-btp-1.1.2.tgz",
+      "integrity": "sha1-EWIk0MfOm6cs5xlN8ff1MRJTjko=",
       "requires": {
         "base64url": "2.0.0",
         "btp-packet": "1.2.0",
         "debug": "3.1.0",
+        "eventemitter2": "5.0.0",
         "ws": "3.3.3"
+      },
+      "dependencies": {
+        "eventemitter2": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.0.tgz",
+          "integrity": "sha1-1/fiVrYxSTgxjl7U/RKsZXJJYsY="
+        }
       }
     },
     "ilp-plugin-payment-channel-framework": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "debug": "^3.1.0",
     "ilp": "^11.4.0",
     "ilp-packet": "^2.1.2",
-    "ilp-plugin-btp": "^1.1.1",
+    "ilp-plugin-btp": "^1.1.3",
     "ilp-plugin-payment-channel-framework": "^1.0.1",
     "ilp-protocol-ildcp": "^1.0.0",
     "int64": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "debug": "^3.1.0",
     "ilp": "^11.4.0",
     "ilp-packet": "^2.1.2",
-    "ilp-plugin-btp": "^1.0.0",
+    "ilp-plugin-btp": "^1.1.1",
     "ilp-plugin-payment-channel-framework": "^1.0.1",
     "ilp-protocol-ildcp": "^1.0.0",
     "int64": "0.0.5",


### PR DESCRIPTION
This does a little restructuring to allow multi-plugins to inherit and extend this class much like other plugins can inherit and extend `ilp-plugin-btp`. An example of this is in https://github.com/sharafian/ilp-plugin-xrp-asym/pull/7 .

Also removes some unused old methods.