### PR TITLE
Require node version >=8.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ const plugin = new IlpPluginMiniAccounts({
   port: 6666
 })
 ```
+
+Note that this module requires node version 8.3.0 or higher.

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1"
+  },
+  "engines": {
+    "node": ">=8.3.0"
   }
 }


### PR DESCRIPTION
The engines field in the package.json doesn't seem to do much, but the warning in the readme should probably work for most people. Fixes #8.