### PR TITLE
Feat: add custom close handler to be defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,13 +66,18 @@ class Plugin extends AbstractBtpPlugin {
       let token
       let account
 
-      wsIncoming.on('close', code => {
-        debug('incoming ws close. code=' + code)
-      })
+      const closeHandler = error => {
+        debug('incoming ws closed. error=', error)
+        if (this._close) {
+          this._close(this._prefix + '.' + account, code)
+            .catch(e => {
+              debug('error during custom close handler. error=', e)
+            })
+        }
+      }
 
-      wsIncoming.on('error', e => {
-        debug('incoming ws error. error=', e)
-      })
+      wsIncoming.on('close', closeHandler)
+      wsIncoming.on('error', closeHandler)
 
       // The first message must be an auth packet
       // with the macaroon as the auth_token

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ class Plugin extends AbstractBtpPlugin {
       const closeHandler = error => {
         debug('incoming ws closed. error=', error)
         if (this._close) {
-          this._close(this._prefix + '.' + account, code)
+          this._close(this._prefix + account, error)
             .catch(e => {
               debug('error during custom close handler. error=', e)
             })


### PR DESCRIPTION
plugins that inherit mini-accounts can define `_close`, which will be called whenever an incoming connection closes.