### PR TITLE
fix: TypeScript compatibility with subclasses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,11 +113,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base64url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.0.tgz",
-      "integrity": "sha512-LIVmqIrIWuiqTvn4RzcrwCOuHo2DD6tKmKBPXXlr4p4n4l6BZBkwFTIa3zu1XkX5MbZgro4a6BvPi+n2Mns5Gg=="
-    },
     "bignumber.js": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
@@ -373,17 +368,6 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-    "ilp-compat-plugin": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ilp-compat-plugin/-/ilp-compat-plugin-2.0.3.tgz",
-      "integrity": "sha512-enMMJJ4T6Q0+GWbyov2Oe/14ikEgmy6feMWGOrXpUy1NtFLskDPGL+GKFG7kJNq5OlqHUz1SUqU224odOE65Cg==",
-      "requires": {
-        "debug": "^3.1.0",
-        "ilp-packet": "^2.1.0",
-        "oer-utils": "^1.3.4",
-        "uuid": "^3.1.0"
-      }
-    },
     "ilp-logger": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ilp-logger/-/ilp-logger-1.0.2.tgz",
@@ -411,34 +395,68 @@
       }
     },
     "ilp-plugin-btp": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/ilp-plugin-btp/-/ilp-plugin-btp-1.1.14.tgz",
-      "integrity": "sha1-Gm6Tuk4tTA9t0a4+wXqzDgCLwc0=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ilp-plugin-btp/-/ilp-plugin-btp-1.3.2.tgz",
+      "integrity": "sha512-EkEeGAghQ1hZt4VFlvtbP3mR/FgbgJ1/WbwaPdvXMyxQCEhU8lObi/r/X0Ksspnw+u0nK0I7Kl6PgXhEVfMp5w==",
       "requires": {
         "@types/debug": "0.0.30",
-        "@types/node": "^8.9.4",
-        "@types/ws": "^4.0.1",
-        "base64url": "^3.0.0",
-        "btp-packet": "^1.2.1",
+        "@types/node": "^10.7.1",
+        "@types/ws": "^6.0.0",
+        "btp-packet": "^2.0.2",
         "debug": "^3.1.0",
         "eventemitter2": "^5.0.0",
-        "ilp-compat-plugin": "^2.0.3",
-        "ilp-logger": "^1.0.1",
-        "ws": "^3.3.3"
+        "ilp-logger": "^1.0.2",
+        "ws": "^6.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.21.tgz",
-          "integrity": "sha512-87XkD9qDXm8fIax+5y7drx84cXsu34ZZqfB7Cial3Q/2lxSoJ/+DRaWckkCbxP41wFSIrrb939VhzaNxj4eY1w=="
+          "version": "10.9.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
+          "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
         },
         "@types/ws": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-4.0.2.tgz",
-          "integrity": "sha512-tlDVFHCcJdNqYgjGNDPDCo4tNqhFMymIAdJCcykFbdhYr4X6vD7IlMxY0t3/k6Pfup68YNkMTpRfLKTRuKDmnQ==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz",
+          "integrity": "sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==",
           "requires": {
             "@types/events": "*",
             "@types/node": "*"
+          }
+        },
+        "bignumber.js": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+        },
+        "btp-packet": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/btp-packet/-/btp-packet-2.0.2.tgz",
+          "integrity": "sha512-f0bugIL4DPRSEjd3aSa69p8tWTxXEz5/lH3j/gKwo4BNnmEV2E/uzpZ4rJI2FIKrg7/KyfY/NRdVTbWS865qAg==",
+          "requires": {
+            "bignumber.js": "^7.2.1",
+            "dateformat": "^3.0.3",
+            "oer-utils": "^3.0.1"
+          }
+        },
+        "dateformat": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+          "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+        },
+        "oer-utils": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-3.0.1.tgz",
+          "integrity": "sha512-cyVlY/pP3zhfb9cpv/lcMlVejaVSLJo4Y5ExP39dEcTYP8JwCReWbglOhFNnxLJT3PFQi+6IHHfOWuDmjW9LyA==",
+          "requires": {
+            "bignumber.js": "^7.2.1"
+          }
+        },
+        "ws": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.0.0.tgz",
+          "integrity": "sha512-c2UlYcAZp1VS8AORtpq6y4RJIkJ9dQz18W32SpR/qXGfLDZ2jU4y4wKvvZwqbi7U6gxFQTeE+urMbXU/tsDy4w==",
+          "requires": {
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -835,11 +853,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-    },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "uuid-parse": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "btp-packet": "^1.2.1",
     "ilp-logger": "^1.0.2",
     "ilp-packet": "^2.2.0",
-    "ilp-plugin-btp": "^1.1.14",
+    "ilp-plugin-btp": "^1.3.2",
     "ilp-protocol-ildcp": "^1.0.0",
     "ilp-store-memory": "^1.0.0",
     "ilp-store-wrapper": "^1.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,6 @@ import { Store, StoreWrapper } from './types'
 const createLogger = require('ilp-logger')
 import { IncomingMessage } from 'http'
 
-export { BtpSubProtocol } from 'ilp-plugin-btp'
-
 const DEBUG_NAMESPACE = 'ilp-plugin-mini-accounts'
 
 function tokenToAccount (token: string): string {
@@ -27,19 +25,6 @@ interface Logger {
   error (...msg: any[]): void
   debug (...msg: any[]): void
   trace (...msg: any[]): void
-}
-
-export type Protocol = {
-  protocolName: string
-  contentType: number
-  data: Buffer
-}
-
-export interface BtpData {
-  data: {
-    protocolData: Protocol[]
-  }
-  requestId: number
 }
 
 /* tslint:disable-next-line:no-empty */
@@ -94,11 +79,9 @@ export default class Plugin extends AbstractBtpPlugin {
   /* tslint:disable:no-empty */
   // These can be overridden.
   protected async _preConnect (): Promise<void> {}
-  // FIXME: right now plugin-btp and plugin-mini-accounts use different signatures
-  // for _connect -- ideally mini-accounts would use a different function name, but
-  // this is as close as it can get without being a breaking change.
-  // @ts-ignore
-  protected async _connect (address: string, authPacket: BtpData, opts: {
+  // plugin-btp and plugin-mini-accounts use slightly different signatures for _connect
+  // making the mini-accounts params optional makes them kinda compatible
+  protected async _connect (address: string, authPacket: BtpPlugin.BtpPacket, opts: {
     ws: WebSocket,
     req: IncomingMessage
   }): Promise<void> {}


### PR DESCRIPTION
- The difference in _connect between plugin-btp and mini-accounts prevented extending it in TS, but making the parameters optional in plugin-btp resolves that
- Depends upon interledgerjs/ilp-plugin-btp#31