### PR TITLE
feat: add opts.generateAccount

### DIFF
--- a/test/helper/btp-util.js
+++ b/test/helper/btp-util.js
@@ -3,7 +3,7 @@
 const BtpPacket = require('btp-packet')
 const WebSocket = require('ws')
 
-module.exports = async function sendAuthPaket (serverUrl, account, token) {
+module.exports = async function sendAuthPacket (serverUrl, account, token) {
   const protocolData = [{
     protocolName: 'auth',
     contentType: BtpPacket.MIME_APPLICATION_OCTET_STREAM,

--- a/test/helper/btp-util.js
+++ b/test/helper/btp-util.js
@@ -19,13 +19,18 @@ module.exports = async function sendAuthPacket (serverUrl, account, token) {
   }]
 
   const ws = new WebSocket(serverUrl)
-  await new Promise(resolve => {
-    ws.on('open', () => resolve())
+  await new Promise((resolve, reject) => {
+    ws.once('open', () => resolve())
+    ws.once('error', (err) => reject(err))
   })
 
-  const result = new Promise(resolve => ws.on('message', (msg) => {
-    resolve(BtpPacket.deserialize(msg))
-  }))
+
+  const result = new Promise((resolve) => {
+    ws.on('message', (msg) => {
+      resolve(BtpPacket.deserialize(msg))
+      ws.close()
+    })
+  })
 
   await new Promise((resolve) => ws.send(BtpPacket.serialize({
     type: BtpPacket.TYPE_MESSAGE,

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -11,7 +11,7 @@ const sinon = require('sinon')
 
 const PluginMiniAccounts = require('..')
 const Store = require('ilp-store-memory')
-const sendAuthPaket = require('./helper/btp-util')
+const sendAuthPacket = require('./helper/btp-util')
 const Token = require('../src/token').default
 
 function sha256 (token) {
@@ -51,7 +51,7 @@ describe('Mini Accounts Plugin', () => {
     describe('new account', function () {
       it('stores hashed token if account does not exist', async function () {
         const spy = sinon.spy(this.plugin._store, 'set')
-        await sendAuthPaket(this.serverUrl, 'acc', 'secret_token')
+        await sendAuthPacket(this.serverUrl, 'acc', 'secret_token')
 
         // assert that a new account was written to the store with a hashed token
         const expectedToken = sha256('secret_token')
@@ -63,11 +63,11 @@ describe('Mini Accounts Plugin', () => {
         const realStoreLoad = this.plugin._store.load.bind(this.plugin._store)
         sinon.stub(this.plugin._store, 'load').onFirstCall().callsFake(async (...args) => {
           // forces a race condition
-          await sendAuthPaket(this.serverUrl, 'acc', '2nd_secret_token')
+          await sendAuthPacket(this.serverUrl, 'acc', '2nd_secret_token')
           return realStoreLoad(...args)
         })
 
-        const msg = await sendAuthPaket(this.serverUrl, 'acc', '1st_secret_token')
+        const msg = await sendAuthPacket(this.serverUrl, 'acc', '1st_secret_token')
         assert.strictEqual(msg.type, BtpPacket.TYPE_ERROR, 'expected an BTP error')
         assert.strictEqual(msg.data.code, 'F00')
         assert.strictEqual(msg.data.name, 'NotAcceptedError')
@@ -87,7 +87,7 @@ describe('Mini Accounts Plugin', () => {
       })
 
       it('fails if received token does not match stored token', async function () {
-        const msg = await sendAuthPaket(this.serverUrl, 'acc', 'wrong_token')
+        const msg = await sendAuthPacket(this.serverUrl, 'acc', 'wrong_token')
 
         assert.strictEqual(msg.type, BtpPacket.TYPE_ERROR, 'expected an BTP error')
         assert.strictEqual(msg.data.code, 'F00')
@@ -96,7 +96,7 @@ describe('Mini Accounts Plugin', () => {
       })
 
       it('succeeds if received token matches stored token', async function () {
-        const msg = await sendAuthPaket(this.serverUrl, 'acc', 'secret_token')
+        const msg = await sendAuthPacket(this.serverUrl, 'acc', 'secret_token')
         assert.strictEqual(msg.type, BtpPacket.TYPE_RESPONSE)
       })
 


### PR DESCRIPTION
mini-accounts leaks memory when it unnecessarily stores account/token pairs for accounts where `account == sha256(token)`.

Setting `generateAccount` to `true` prevents any records from being stored. It should be used whenever mini-accounts is being used with dynamically (or user) generated tokens.

Setting `generateAccount` to `false` makes the `auth_username` subprotocol required.

mini-accounts default behavior has not change.