### PR TITLE
fix: update ilp-packet, add outgoing expiry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -377,20 +377,27 @@
       }
     },
     "ilp-packet": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
-      "integrity": "sha1-qHJcwmMxxuLGU1OKEGPVUBQwXjE=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-3.0.4.tgz",
+      "integrity": "sha512-8Mr960l6ec2soK9WswRBm/NZZiMMumXLJ3n9SHOi0peeNjsH9oNhgvFWjnpXBWvgX+rwb0ciz8QCMt+2YVhHHQ==",
       "requires": {
-        "bignumber.js": "^5.0.0",
         "extensible-error": "^1.0.2",
-        "long": "^3.2.0",
-        "oer-utils": "^1.3.2"
+        "long": "^4.0.0",
+        "oer-utils": "^3.2.0"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
-          "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+        },
+        "oer-utils": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-3.2.0.tgz",
+          "integrity": "sha512-WYDTeRW15E1u+hfrIJQwAzLBFu/FAOiMgRa5j/sgrvED0gYbqkKZ4ApQgfdEMiXFzvEmdKQlGcUqmloz6y+WZg==",
+          "requires": {
+            "bignumber.js": "^7.2.1"
+          }
         }
       }
     },
@@ -468,6 +475,29 @@
       "requires": {
         "ilp-packet": "^2.1.2",
         "oer-utils": "^1.3.4"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+          "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+        },
+        "ilp-packet": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
+          "integrity": "sha1-qHJcwmMxxuLGU1OKEGPVUBQwXjE=",
+          "requires": {
+            "bignumber.js": "^5.0.0",
+            "extensible-error": "^1.0.2",
+            "long": "^3.2.0",
+            "oer-utils": "^1.3.2"
+          }
+        },
+        "long": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+        }
       }
     },
     "ilp-store-memory": {
@@ -542,9 +572,9 @@
       "dev": true
     },
     "long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "make-error": {
       "version": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.6.0",
   "description": "Plugin that implements a mini ephemeral ledger",
   "main": "index.js",
-  "types": "src/index.d.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc --project .",
     "test": "mocha",
@@ -35,7 +35,7 @@
     "@types/ws": "^5.1.2",
     "btp-packet": "^1.2.1",
     "ilp-logger": "^1.0.2",
-    "ilp-packet": "^2.2.0",
+    "ilp-packet": "^3.0.4",
     "ilp-plugin-btp": "^1.3.2",
     "ilp-protocol-ildcp": "^1.0.0",
     "ilp-store-memory": "^1.0.0",

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -213,5 +213,27 @@ describe('Mini Accounts Plugin', () => {
         data: Buffer.alloc(0)
       })
     })
+
+    it('should return ilp reject when the prepare expires', async function () {
+      this.plugin._call = () => new Promise(() => {})
+
+      const result = await this.plugin.sendData(IlpPacket.serializeIlpPrepare({
+        destination: this.from,
+        amount: '123',
+        executionCondition: this.condition,
+        expiresAt: new Date(Date.now() + 50),
+        data: Buffer.alloc(0)
+      }))
+
+      const parsed = IlpPacket.deserializeIlpPacket(result)
+
+      assert.equal(parsed.typeString, 'ilp_reject')
+      assert.deepEqual(parsed.data, {
+        code: 'R00',
+        triggeredBy: 'test.example',
+        message: 'Packet expired',
+        data: Buffer.alloc(0)
+      })
+    })
   })
 })


### PR DESCRIPTION
- update ILP packet to v3 for performance improvements
- remove handling of deprecated ILP packets
- fix types in package.json
- add expiry timeout for outgoing packets with test case