### PR TITLE
bug: wasn't checking for port in wsOpts.port

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,15 @@ export default class Plugin extends AbstractBtpPlugin {
   constructor (opts: IlpPluginMiniAccountsConstructorOptions,
     { log, store }: IlpPluginMiniAccountsConstructorModules = {}) {
     super({})
-    this._port = opts.port || 3000
+    if (opts.wsOpts && opts.wsOpts.port && opts.port) {
+      throw new Error('Specify at most one of: `ops.wsOpts.port`, `opts.port`.')
+    } else if (opts.wsOpts && opts.wsOpts.port) {
+      this._port = opts.wsOpts.port
+    } else if (opts.port) {
+      this._port = opts.port
+    } else {
+      this._port = 3000
+    }
     this._wsOpts = opts.wsOpts || { port: this._port }
     if (this._wsOpts.server) {
       this._httpServer = this._wsOpts.server

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -278,6 +278,16 @@ describe('Mini Accounts http requests', function() {
       assert.equal(res.status, 426)
       assert.equal(await res.text(), 'Upgrade Required')
     })
+    it('doesnt let user specify both opts.wsOpt.port and opts.port', async function() {
+      const constructPlugin = () => new PluginMiniAccounts({
+        ...this.pluginConfig,
+        port: this.port,
+        wsOpts: {
+          port: this.port
+        }
+      })
+      assert.throws(constructPlugin, 'Specify at most one of: `ops.wsOpts.port`, `opts.port`.')
+    })
     it('fails health check when port unspecified, wsOpt.port specified', async function() {
       this.plugin = new PluginMiniAccounts({
         ...this.pluginConfig,


### PR DESCRIPTION
Port can be defined in the constructor 3 different ways:

1. through `opts.port`
2. through `opts.wsOpts.port`
3. not passed in, in which case a default port (`3000`) is used

The bug to be fixed was that these checks were not exhaustive and `this._port` was used erroneously on lines 169 and 172:

```
    this._log.info('listening on port ' + this._port)

    if (this._httpServer) {
      this._httpServer.listen(this._port)
    }
```

If port was defined through `opts.wsOpts.port`, the plugin would still use the default port `3000`. Luckily the logger also used `this._port` so the error was easy to spot.