### PR TITLE
patch: ConstructorModules now uses Store rather than StoreWrapper 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export interface IlpPluginMiniAccountsConstructorOptions {
 
 export interface IlpPluginMiniAccountsConstructorModules {
   log?: Logger
-  store?: StoreWrapper
+  store?: Store
 }
 
 enum AccountMode {


### PR DESCRIPTION
[4.0.3](https://github.com/interledgerjs/ilp-plugin-mini-accounts/pull/43) refactored the constructor modules into its own exported interface `IlpPluginMiniAccountsConstructorModules`. Unfortunately, I mistakenly gave the store option the type `StoreWrapper` instead of `Store`, leading to breaking changes as reported by @kincaidoneil and @karzak. Terribly sorry for any problems this caused to users of this package.