### PR TITLE
feat: dont send to closed websockets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -621,9 +621,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
- Don't send to closed/failed websockets.
- Use `%` formatting for logging. This should avoid `JSON.stringify`ing the objects when debug/trace aren't enabled.
- Update vulnerable package in `package-lock.json`.

Sending to a closed websocket causes:

```
(node:27) UnhandledPromiseRejectionWarning: Error: not opened
    at WebSocket.send (/app/node_modules/ws/lib/WebSocket.js:360:18)
    at PluginFlatStacks.<anonymous> (/app/node_modules/@coil/ilp-plugin-flat-stacks/node_modules/ilp-plugin-mini-accounts/src/index.ts:270:24)
    at Generator.throw (<anonymous>)
    at rejected (/app/node_modules/@coil/ilp-plugin-flat-stacks/node_modules/ilp-plugin-mini-accounts/src/index.js:5:65)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```